### PR TITLE
Clear out dev dependencies when running release, remove require/require-dev sections of composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `action-release` will be documented in this file.
 
+## 0.2.0 - 2024-12-06
+
+- Prevent development dependencies from being installed during release.
+
 ## 0.1.0 - 2024-09-05
 
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `action-release` will be documented in this file.
 ## 0.2.0 - 2024-12-06
 
 - Prevent development dependencies from being installed during release.
+- Clear out the `require` and `require-dev` sections of Composer during installation.
 
 ## 0.1.0 - 2024-09-05
 

--- a/action.yml
+++ b/action.yml
@@ -188,10 +188,9 @@ runs:
       if: inputs.skip-composer-install != 'true' && inputs.skip-composer-require-removal != 'true'
       shell: bash
       run: |
-        cp composer.json composer.json.bak # Backup original
         jq 'del(.require, .["require-dev"])' composer.json > composer.json.tmp
         mv composer.json.tmp composer.json
-        rm -rf composer.lock || true
+        rm -rf composer.lock composer.json.bak || true
 
     - name: NPM Install and Build
       uses: alleyinteractive/action-test-node@develop

--- a/action.yml
+++ b/action.yml
@@ -173,6 +173,7 @@ runs:
       if: inputs.skip-composer-install != 'true'
       uses: alleyinteractive/action-test-php@develop
       with:
+        install-command: 'composer install --prefer-dist --no-interaction --no-progress --no-dev --optimize-autoloader'
         php-version: '${{ inputs.php-version }}'
         skip-audit: 'true'
         skip-services: 'true'

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Specify whether to skip the composer install step.'
     required: false
     default: 'false'
+  skip-composer-require-removal:
+    description: 'Skip the removal of the require/require-dev sections in the composer.json file'
+    default: 'false'
+    required: false
   skip-npm-install:
     description: 'Specify whether to skip the npm install step.'
     required: false
@@ -179,6 +183,15 @@ runs:
         skip-services: 'true'
         skip-test: 'true'
         skip-wordpress-install: 'true'
+
+    - name: Clear composer require/require-dev
+      if: inputs.skip-composer-install != 'true' && inputs.skip-composer-require-removal != 'true'
+      shell: bash
+      run: |
+        cp composer.json composer.json.bak # Backup original
+        jq 'del(.require, .["require-dev"])' composer.json > composer.json.tmp
+        mv composer.json.tmp composer.json
+        rm -rf composer.lock || true
 
     - name: NPM Install and Build
       uses: alleyinteractive/action-test-node@develop


### PR DESCRIPTION
Aiming to prevent packages from installing dependencies that are already included with a plugin, we're going to remove the `require`/`require-dev` sections of the built release's `composer.json` files. The non-built version will still have the proper sections for development.

Example:
- [Cleaned release](https://packagist.org/packages/alleyinteractive/wp-alleyvate#v3.5.1)
- [Uncleaned release](https://packagist.org/packages/alleyinteractive/wp-alleyvate#v3.5.0)
- [Main development branch](https://packagist.org/packages/alleyinteractive/wp-alleyvate#dev-main)

Releases should also not install development dependencies. This is causing a conflict on a PHPUnit 9 project that is requiring wp-alleyvate (which installs PHPUnit 11).