### PR TITLE
Change the default PHP version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   php-version:
     description: 'Specify the version of PHP to use.'
     required: false
-    default: '8.1'
+    default: '8.2'
   skip-build:
     description: 'Specify whether to skip the build step.'
     required: false


### PR DESCRIPTION
Mirrors the default version used in `create-wordpress-plugin`.