### PR TITLE
Disable composer require clearing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -184,13 +184,15 @@ runs:
         skip-test: 'true'
         skip-wordpress-install: 'true'
 
-    - name: Clear composer require/require-dev
-      if: inputs.skip-composer-install != 'true' && inputs.skip-composer-require-removal != 'true'
-      shell: bash
-      run: |
-        jq 'del(.require, .["require-dev"])' composer.json > composer.json.tmp
-        mv composer.json.tmp composer.json
-        rm -rf composer.lock composer.json.bak || true
+    # Disabled until we are able to address scoped Composer dependencies:
+    # https://github.com/alleyinteractive/create-wordpress-plugin/issues/309
+    # - name: Clear composer require/require-dev
+    #   if: inputs.skip-composer-install != 'true' && inputs.skip-composer-require-removal != 'true'
+    #   shell: bash
+    #   run: |
+    #     jq 'del(.require, .["require-dev"])' composer.json > composer.json.tmp
+    #     mv composer.json.tmp composer.json
+    #     rm -rf composer.lock composer.json.bak || true
 
     - name: NPM Install and Build
       uses: alleyinteractive/action-test-node@develop


### PR DESCRIPTION
Disable the clearing out of a plugin's `composer.json` `require`/`require-dev` sections during release.

This change caused plugins' dependencies to be used over a root project's dependency. For example, a plugin may require `vendor/package v2` but the root requires `v3`. If the plugin is loaded first, then the v2 of the package will be loaded and the root project will be none the wiser.

The proper solution is to figure out Composer namespace scoping in https://github.com/alleyinteractive/create-wordpress-plugin/issues/309 which is fairly complicated.