### PR TITLE
Add scope input for scoped Composer dependencies (#309)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Specify whether to skip the npm install step.'
     required: false
     default: 'false'
+  scope:
+    description: 'Scope (prefix) the plugin''s Composer dependencies via `composer scope` before release. Requires the plugin to be configured for scoping (create-wordpress-plugin).'
+    required: false
+    default: 'false'
   use-changelog-notes:
     description: 'Use notes from the CHANGELOG.md file (if found) instead of generating release notes.'
     required: false
@@ -310,7 +314,7 @@ runs:
         fi
 
     - name: Composer Install
-      if: inputs.skip-composer-install != 'true'
+      if: inputs.skip-composer-install != 'true' && inputs.scope != 'true'
       uses: alleyinteractive/action-test-php@develop
       with:
         install-command: 'composer install --prefer-dist --no-interaction --no-progress --no-dev --optimize-autoloader'
@@ -320,15 +324,37 @@ runs:
         skip-test: 'true'
         skip-wordpress-install: 'true'
 
-    # Disabled until we are able to address scoped Composer dependencies:
-    # https://github.com/alleyinteractive/create-wordpress-plugin/issues/309
-    # - name: Clear composer require/require-dev
-    #   if: inputs.skip-composer-install != 'true' && inputs.skip-composer-require-removal != 'true'
-    #   shell: bash
-    #   run: |
-    #     jq 'del(.require, .["require-dev"])' composer.json > composer.json.tmp
-    #     mv composer.json.tmp composer.json
-    #     rm -rf composer.lock composer.json.bak || true
+    # When scoping, dev tooling (php-scoper) must be present, so dev
+    # dependencies are installed. They are not shipped: only the prefixed
+    # vendor-prefixed/ directory is committed to the built branch (vendor/ is
+    # excluded via the plugin's .deployignore), and the require/require-dev
+    # sections are pruned below.
+    - name: Composer Install (with scoping)
+      if: inputs.skip-composer-install != 'true' && inputs.scope == 'true'
+      uses: alleyinteractive/action-test-php@develop
+      with:
+        install-command: 'composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader'
+        php-version: '${{ steps.extract-php-version.outputs.value }}'
+        skip-audit: 'true'
+        skip-services: 'true'
+        skip-test: 'true'
+        skip-wordpress-install: 'true'
+
+    - name: Scope Composer dependencies
+      if: inputs.skip-composer-install != 'true' && inputs.scope == 'true'
+      shell: bash
+      run: composer scope
+
+    # Prune require/require-dev so the released artifact does not re-resolve
+    # (and re-conflict) dependencies when installed. Enabled when scoping, since
+    # the prefixed dependencies ship in vendor-prefixed/ instead.
+    - name: Clear composer require/require-dev
+      if: inputs.skip-composer-install != 'true' && inputs.scope == 'true' && inputs.skip-composer-require-removal != 'true'
+      shell: bash
+      run: |
+        jq 'del(.require, .["require-dev"])' composer.json > composer.json.tmp
+        mv composer.json.tmp composer.json
+        rm -rf composer.lock composer.json.bak || true
 
     - name: NPM Install and Build
       uses: alleyinteractive/action-test-node@develop


### PR DESCRIPTION
Adds release-time support for scoped Composer dependencies, unblocking the require-pruning step that was previously commented out citing alleyinteractive/create-wordpress-plugin#309.

Pairs with alleyinteractive/create-wordpress-plugin#537, which adds the opt-in scoping machinery (`.scoper/`, `composer scope`) to the plugin template.

## What

New **`scope`** input (default `false`, fully backward compatible). When `scope: true`:

1. Composer installs **with** dev dependencies (so `php-scoper` is available) instead of `--no-dev`.
2. Runs `composer scope`, which prefixes runtime dependencies into `vendor-prefixed/`.
3. Prunes `require`/`require-dev` from `composer.json` so the released artifact doesn't re-resolve (and re-conflict) dependencies when installed.

The prefixed `vendor-prefixed/` directory is what ships; the plugin's `.deployignore` excludes `vendor/`, so dev dependencies installed in step 1 are never committed to the built branch.

When `scope` is `false` (the default), behaviour is unchanged: the existing `--no-dev` install runs and nothing is pruned.

## Usage

A scoped plugin's `built-release.yml` opts in:

```yaml
- uses: alleyinteractive/action-release@develop
  with:
    scope: true
```

## Notes

- YAML validated.
- Behavioural verification depends on a downstream scoped plugin (create-wordpress-plugin#537); recommend testing together against a scoped fixture before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)